### PR TITLE
Increase bounty feature frequencies

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -158,9 +158,9 @@ class GuildPoints(commands.Cog):
         if message.author.bot:
             return
         members = [m for m in message.guild.members if not m.bot]
-        if message.author == random.choice(message.guild.members):
+        if random.randint(1, 25) == random.randint(1, 25):
             await self.award_tickets(message)
-            if message.channel == random.choice(message.guild.channels):
+            if random.choice(message.guild.members).id == message.author.id:
                 await self.create_bounty(message)
 
     @commands.Cog.listener()


### PR DESCRIPTION
- `on_message`: The bot will randomly select two numbers, between 1 and 25, inclusive. If those two numbers are the same, then bounty tickets are distributed
- `on_message`: If a member receives tickets, the bot will randomly select a member from the guild. If the member of the guild is the same member who sent the message, a bounty will be started.

Close #36 